### PR TITLE
when expanding the snippet I want to keep my typed text!!!

### DIFF
--- a/pythonx/cm_sources/cm_tern.py
+++ b/pythonx/cm_sources/cm_tern.py
@@ -164,7 +164,7 @@ class Source(Base):
                     # There's optional args, don't jump out of parentheses
                     optional = '${1}'
 
-                item['snippet'] = item['word'] + '(' + ", ".join(snip_params) + optional + ')${0}'
+                item['snippet'] = typed + item['word'] + '(' + ", ".join(snip_params) + optional + ')${0}'
 
         # cm#complete(src, context, startcol, matches)
         ret = self.nvim.call('cm#complete', info['name'], ctx, ctx['startcol'], matches)


### PR DESCRIPTION
eg: I type `routers.` get offered 

![screen shot 2017-08-08 at 19 09 25](https://user-images.githubusercontent.com/4605383/29082098-33dda7c4-7c6d-11e7-8374-03b139d3c6f1.png)

when I expand the snippet I expect the `routers.` prefix to still be there
